### PR TITLE
refactor: update extension download buttons size (height)

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,9 +56,15 @@
                 Secure and high-performance, RR Adblocker provides a Lightning Fast Browsing Experience powered by Adblocking, Tracker Blocking and Malware Protection!
               </p>
               <div class="cta">
-                <a href="https://bit.ly/rradb_chrome"><img src="./img/chrome.png" style="border-radius: 20px;"></a>
-                <a href="https://addons.mozilla.org/en-US/firefox/addon/rr-adblocker/" target="blank" ><img src="./img/firefox.png" style="border-radius: 20px;"></a>
-                <a href="https://bit.ly/rr-adblocker_microsoft-edge" target="blank"><img src="./img/edge.png" style="border-radius: 20px;"></a>
+                <a class="cta-link" href="https://bit.ly/rradb_chrome" target="_blank">
+                  <img class="cta-extension" src="./img/chrome.png" alt="Chrome Web Store" />
+                </a>
+                <a class="cta-link" href="https://addons.mozilla.org/en-US/firefox/addon/rr-adblocker/" target="blank">
+                  <img class="cta-extension" src="./img/firefox.png" alt="Mozilla Store" />
+                </a>
+                <a class="cta-link" href="https://bit.ly/rr-adblocker_microsoft-edge" target="blank">
+                  <img class="cta-extension" src="./img/edge.png" alt="Microsoft Store" />
+                </a>
               </div>
             </div>
 

--- a/style.css
+++ b/style.css
@@ -206,6 +206,16 @@ header .container {
   line-height: 1.4;
 }
 
+.cta-link {
+  display: inline-block;
+  font-size: 0;
+}
+
+.cta-extension {
+  max-height: 58px;
+  border-radius: 20px;
+}
+
 .text {
   color: var(--lightOne);
   font-size: 1.1rem;


### PR DESCRIPTION
How it looks like right now:

<img width="646" alt="image" src="https://user-images.githubusercontent.com/5417662/194749257-db0a9b02-e058-49d3-ac89-0d768761d4c3.png">

----

**Reference:** https://github.com/Rutuj-Runwal/RR-Adblocker/issues/35